### PR TITLE
Re-raise original exception

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 vividmuimui
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/core_ext/kernel.rb
+++ b/lib/core_ext/kernel.rb
@@ -3,10 +3,10 @@ module Kernel
     count   ||= 0
     options ||= WithRetry::Functions.build_options(args)
     yield
-  rescue options[:on]
+  rescue options[:on] => e
     if (count += 1) > options[:limit]
       options[:before_giving_up].call
-      raise (options[:failed] || options[:on])
+      raise (options[:failed] || e)
     else
       options[:before_retrying].call
       sleep options[:sleep]

--- a/test/test_kernel.rb
+++ b/test/test_kernel.rb
@@ -26,4 +26,14 @@ class TestKernel < Minitest::Test
       with_retry(failed: NotImplementedError) { fail }
     end
   end
+
+  class ArgumentRequiredError < StandardError
+    def initialize(dummy); end
+  end
+
+  def test_with_retry_by_argument_required_error
+    assert_raises(ArgumentRequiredError) do
+      with_retry(on: ArgumentRequiredError) { raise ArgumentRequiredError.new('dummy') }
+    end
+  end
 end


### PR DESCRIPTION
# old behavior

```ruby
irb(main):001:0> require "with_retry"
=> true
irb(main):002:0>
irb(main):003:0* class ArgumentRequiredError < StandardError
irb(main):004:1>   def initialize(dummy)
irb(main):005:2>     # some logic
irb(main):006:2*     super(dummy)
irb(main):007:2>   end
irb(main):008:1> end
=> :initialize
irb(main):009:0> with_retry(on: ArgumentRequiredError) { raise ArgumentRequiredError.new('dummy') }
ArgumentError: wrong number of arguments (given 0, expected 1)
```

# new behavior

```ruby
irb(main):009:0> with_retry(on: ArgumentRequiredError) { raise ArgumentRequiredError.new('dummy') }
ArgumentRequiredError: dummy
```
